### PR TITLE
Added Single Action controllers

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,11 @@
             "Beast\\Framework\\": "src/"
         }
     },
+    "autoload-dev": {
+        "psr-4": {
+            "Beast\\Framework\\Tests\\": "tests/"
+        }
+    },
     "config": {
         "preferred-install": "dist",
         "sort-packages": true,

--- a/src/Http/Resolver.php
+++ b/src/Http/Resolver.php
@@ -28,6 +28,17 @@ class Resolver implements ResolverInterface
     ): ResponseInterface {
         $controller = $route->getController();
 
+        // Single Action Controllers (Invokable Controllers)
+        if (is_string($controller) && class_exists($controller)) {
+            $instance = $this->container->get($controller);
+
+            if ($instance instanceof ContainerAwareInterface) {
+                $instance->setContainer($this->container);
+            }
+
+            return $instance($request, $response, $route->getParams());
+        }
+
         if (\is_array($controller) && \count($controller) === 2) {
             [$class, $method] = $controller;
 

--- a/tests/Fixtures/ExampleController.php
+++ b/tests/Fixtures/ExampleController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Beast\Framework\Tests\Fixtures;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class ExampleController
+{
+    public function __invoke(ServerRequestInterface $request, ResponseInterface $response)
+    {
+        $response->getBody()->write('Hello World');
+
+        return $response;
+    }
+}

--- a/tests/Http/ResolverTest.php
+++ b/tests/Http/ResolverTest.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Beast\Framework\Tests\Http;
+
+use Beast\Framework\Http\Resolver;
+use Beast\Framework\Router\Route;
+use Beast\Framework\Tests\Fixtures\ExampleController;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
+
+class ResolverTest extends TestCase
+{
+    public function testResolvesToSingleActionController(): void
+    {
+        $containerMock = $this->createMock(ContainerInterface::class);
+        $requestMock = $this->createMock(ServerRequestInterface::class);
+        $responseMock = $this->createMock(ResponseInterface::class);
+        $streamMock = $this->createMock(StreamInterface::class);
+        $route = new Route('GET', '/foo', ExampleController::class);
+
+        $containerMock->expects($this->once())
+            ->method('get')
+            ->with(ExampleController::class)
+            ->willReturn(new ExampleController())
+        ;
+
+        $responseMock->expects($this->once())
+            ->method('getBody')
+            ->willReturn($streamMock)
+        ;
+
+        $streamMock->expects($this->once())
+            ->method('write')
+            ->with('Hello World');
+
+        $resolver = new Resolver($containerMock);
+
+        $resolver->resolve($requestMock, $responseMock, $route);
+    }
+}


### PR DESCRIPTION
This MR adds support for invokable controllers. Very useful for extracting Closure-based actions into reusable units of code.

```php
class PreviewPDF
{
    private PDFRepository $repository;

    function __construct(PDFRepository $repository)
    {
        $this->repository = $repository;
    }

    public function __invoke(ServerRequestInterface $request, ResponseInterface $response)
    {
          $response->getBody()->write($this->repository->fetch($request->getQueryParams['id']);

          return $response;
    }
}

$route->get('/pdf/preview', PreviewPDF::class);
```