### PR TITLE
Drop controller@method support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,15 +3,18 @@ name: CI
 on: [push]
 
 jobs:
-  build-test:
+  phpstan:
     runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2
       - uses: php-actions/composer@v6
-      - uses: php-actions/phpstan@v3
+      - name: PHPStan 7.4
+        uses: php-actions/phpstan@v3
         with:
           path: src/
+          php_version: 7.4
+          configuration: phpstan.neon
 
   unit-tests:
     runs-on: ubuntu-latest
@@ -19,9 +22,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: php-actions/composer@v6
-      - name: PHPUnit tests
+      - name: PHPUnit tests 7.4
         uses: php-actions/phpunit@v3
+        env:
+          XDEBUG_MODE: coverage
         with:
           php_version: 7.4
           bootstrap: vendor/autoload.php
           php_extensions: xdebug mbstring redis
+          args: --coverage-text

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: php-actions/composer@v6 # or alternative dependency management
-    - uses: php-actions/phpstan@v3
-      with:
-        path: src/
+      - uses: actions/checkout@v2
+      - uses: php-actions/composer@v6 # or alternative dependency management
+      - uses: php-actions/phpstan@v3
+        with:
+          path: src/
+
+  unit-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: PHPUnit tests
+        uses: php-actions/phpunit@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v2
+      - uses: php-actions/composer@v6
       - name: PHPUnit tests
         uses: php-actions/phpunit@v3
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,14 @@
+name: CI
+
+on: [push]
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: php-actions/composer@v6 # or alternative dependency management
+    - uses: php-actions/phpstan@v3
+      with:
+        path: src/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,3 +19,5 @@ jobs:
     steps:
       - name: PHPUnit tests
         uses: php-actions/phpunit@v3
+        with:
+          configuration: phpunit.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,20 +3,6 @@ name: CI
 on: [push]
 
 jobs:
-  phpstan73:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-      - uses: php-actions/composer@v6
-        with:
-          version: 2
-      - name: PHPStan 7.3
-        uses: php-actions/phpstan@v3
-        with:
-          path: src/
-          php_version: 7.3
-          configuration: phpstan.neon
 
   phpstan74:
     runs-on: ubuntu-latest
@@ -62,24 +48,6 @@ jobs:
           path: src/
           php_version: 8.1
           configuration: phpstan.neon
-
-  unit-tests73:
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v2
-      - uses: php-actions/composer@v6
-        with:
-          version: 2
-      - name: PHPUnit tests 7.3
-        uses: php-actions/phpunit@v3
-        env:
-          XDEBUG_MODE: coverage
-        with:
-          php_version: 7.3
-          bootstrap: vendor/autoload.php
-          php_extensions: xdebug mbstring redis
-          args: --coverage-text
 
   unit-tests74:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,4 @@ jobs:
         with:
           php_version: 7.4
           bootstrap: vendor/autoload.php
-          php_extensions:
-            - xdebug
-            - mbstring
-            - redis
+          php_extensions: xdebug mbstring redis

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,11 +9,25 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: php-actions/composer@v6
+        with:
+          version: 2
       - name: PHPStan 7.4
         uses: php-actions/phpstan@v3
         with:
           path: src/
           php_version: 7.4
+          configuration: phpstan.neon
+      - name: PHPStan 8.0
+        uses: php-actions/phpstan@v3
+        with:
+          path: src/
+          php_version: 8.0
+          configuration: phpstan.neon
+      - name: PHPStan 8.1
+        uses: php-actions/phpstan@v3
+        with:
+          path: src/
+          php_version: 8.1
           configuration: phpstan.neon
 
   unit-tests:
@@ -22,12 +36,32 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - uses: php-actions/composer@v6
+        with:
+          version: 2
       - name: PHPUnit tests 7.4
         uses: php-actions/phpunit@v3
         env:
           XDEBUG_MODE: coverage
         with:
           php_version: 7.4
+          bootstrap: vendor/autoload.php
+          php_extensions: xdebug mbstring redis
+          args: --coverage-text
+      - name: PHPUnit tests 8.0
+        uses: php-actions/phpunit@v3
+        env:
+          XDEBUG_MODE: coverage
+        with:
+          php_version: 8.0
+          bootstrap: vendor/autoload.php
+          php_extensions: xdebug mbstring redis
+          args: --coverage-text
+      - name: PHPUnit tests 8.1
+        uses: php-actions/phpunit@v3
+        env:
+          XDEBUG_MODE: coverage
+        with:
+          php_version: 8.1
           bootstrap: vendor/autoload.php
           php_extensions: xdebug mbstring redis
           args: --coverage-text

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,21 @@ name: CI
 on: [push]
 
 jobs:
+  phpstan73:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: php-actions/composer@v6
+        with:
+          version: 2
+      - name: PHPStan 7.3
+        uses: php-actions/phpstan@v3
+        with:
+          path: src/
+          php_version: 7.3
+          configuration: phpstan.neon
+
   phpstan74:
     runs-on: ubuntu-latest
 
@@ -47,6 +62,24 @@ jobs:
           path: src/
           php_version: 8.1
           configuration: phpstan.neon
+
+  unit-tests73:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: php-actions/composer@v6
+        with:
+          version: 2
+      - name: PHPUnit tests 7.3
+        uses: php-actions/phpunit@v3
+        env:
+          XDEBUG_MODE: coverage
+        with:
+          php_version: 7.3
+          bootstrap: vendor/autoload.php
+          php_extensions: xdebug mbstring redis
+          args: --coverage-text
 
   unit-tests74:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,4 +20,4 @@ jobs:
       - name: PHPUnit tests
         uses: php-actions/phpunit@v3
         with:
-          configuration: /home/runner/work/beast/beast/phpunit.xml
+          php_version: 7.4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ name: CI
 on: [push]
 
 jobs:
-  phpstan:
+  phpstan74:
     runs-on: ubuntu-latest
 
     steps:
@@ -17,12 +17,30 @@ jobs:
           path: src/
           php_version: 7.4
           configuration: phpstan.neon
+
+  phpstan80:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: php-actions/composer@v6
+        with:
+          version: 2
       - name: PHPStan 8.0
         uses: php-actions/phpstan@v3
         with:
           path: src/
           php_version: 8.0
           configuration: phpstan.neon
+
+  phpstan81:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: php-actions/composer@v6
+        with:
+          version: 2
       - name: PHPStan 8.1
         uses: php-actions/phpstan@v3
         with:
@@ -30,7 +48,7 @@ jobs:
           php_version: 8.1
           configuration: phpstan.neon
 
-  unit-tests:
+  unit-tests74:
     runs-on: ubuntu-latest
 
     steps:
@@ -47,6 +65,15 @@ jobs:
           bootstrap: vendor/autoload.php
           php_extensions: xdebug mbstring redis
           args: --coverage-text
+
+  unit-tests80:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: php-actions/composer@v6
+        with:
+          version: 2
       - name: PHPUnit tests 8.0
         uses: php-actions/phpunit@v3
         env:
@@ -56,6 +83,15 @@ jobs:
           bootstrap: vendor/autoload.php
           php_extensions: xdebug mbstring redis
           args: --coverage-text
+
+  unit-tests81:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: php-actions/composer@v6
+        with:
+          version: 2
       - name: PHPUnit tests 8.1
         uses: php-actions/phpunit@v3
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: php-actions/composer@v6 # or alternative dependency management
+      - uses: php-actions/composer@v6
       - uses: php-actions/phpstan@v3
         with:
           path: src/
@@ -21,3 +21,4 @@ jobs:
         uses: php-actions/phpunit@v3
         with:
           php_version: 7.4
+          bootstrap: vendor/autoload.php

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,4 +20,4 @@ jobs:
       - name: PHPUnit tests
         uses: php-actions/phpunit@v3
         with:
-          configuration: phpunit.xml
+          configuration: /home/runner/work/beast/phpunit.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,3 +24,7 @@ jobs:
         with:
           php_version: 7.4
           bootstrap: vendor/autoload.php
+          php_extensions:
+            - xdebug
+            - mbstring
+            - redis

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,4 +20,4 @@ jobs:
       - name: PHPUnit tests
         uses: php-actions/phpunit@v3
         with:
-          configuration: /home/runner/work/beast/phpunit.xml
+          configuration: /home/runner/work/beast/beast/phpunit.xml

--- a/composer.json
+++ b/composer.json
@@ -11,17 +11,17 @@
         }
     ],
     "require": {
-        "php": ">=7.2",
+        "php": "^7.3 || ^8.0",
         "doctrine/dbal": "^2",
         "psr/container": "^2",
         "psr/http-message": "^1",
         "psr/http-server-middleware": "^1"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^2",
+        "friendsofphp/php-cs-fixer": "^3",
         "phpstan/phpstan": "^1",
         "phpunit/phpunit": "^9",
-        "symfony/var-dumper": "^4"
+        "symfony/var-dumper": "^6"
     },
     "autoload": {
         "psr-4": {
@@ -41,8 +41,8 @@
     },
     "scripts": {
         "psr": [
-            "./bin/php-cs-fixer fix ./src --allow-risky=yes --rules=@PSR2,no_unused_imports,native_function_invocation,normalize_index_brace,object_operator_without_whitespace,ordered_imports,void_return,psr4",
-            "./bin/php-cs-fixer fix ./tests --allow-risky=yes --rules=@PSR2,no_unused_imports,native_function_invocation,normalize_index_brace,object_operator_without_whitespace,ordered_imports,void_return,psr4"
+            "./bin/php-cs-fixer fix ./src --allow-risky=yes --rules=@PSR2,no_unused_imports,native_function_invocation,normalize_index_brace,object_operator_without_whitespace,ordered_imports,void_return,psr_autoloading",
+            "./bin/php-cs-fixer fix ./tests --allow-risky=yes --rules=@PSR2,no_unused_imports,native_function_invocation,normalize_index_brace,object_operator_without_whitespace,ordered_imports,void_return,psr_autoloading"
         ],
         "uninstall": [
             "rm -rf ./bin",

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^7.4 || ^8.0",
         "doctrine/dbal": "^2",
         "psr/container": "^2",
         "psr/http-message": "^1",

--- a/composer.json
+++ b/composer.json
@@ -12,16 +12,16 @@
     ],
     "require": {
         "php": ">=7.2",
-        "doctrine/dbal": "~2",
-        "psr/container": "~1",
-        "psr/http-message": "~1",
-        "psr/http-server-middleware": "~1"
+        "doctrine/dbal": "^2",
+        "psr/container": "^2",
+        "psr/http-message": "^1",
+        "psr/http-server-middleware": "^1"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "~2",
-        "phpstan/phpstan": "~0",
-        "phpunit/phpunit": "~8",
-        "symfony/var-dumper": "~4"
+        "friendsofphp/php-cs-fixer": "^2",
+        "phpstan/phpstan": "^1",
+        "phpunit/phpunit": "^9",
+        "symfony/var-dumper": "^4"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,6 +1,4 @@
 parameters:
-    level: 7
+    level: max
     paths:
         - %currentWorkingDirectory%/src
-    ignoreErrors:
-        - '#PHPDoc#'

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,16 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="vendor/autoload.php">
-    <testsuites>
-        <testsuite name="Test Suite">
-            <directory suffix="Test.php">./tests</directory>
-        </testsuite>
-    </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="coverage-html" target="./tmp/coverage" />
-    </logging>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="vendor/autoload.php" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <report>
+      <html outputDirectory="./tmp/coverage"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="Test Suite">
+      <directory suffix="Test.php">./tests</directory>
+    </testsuite>
+  </testsuites>
+  <logging/>
 </phpunit>

--- a/src/Config/AbstractFileLoader.php
+++ b/src/Config/AbstractFileLoader.php
@@ -86,12 +86,12 @@ abstract class AbstractFileLoader implements FileLoaderInterface
     {
         [$file, $keys] = $this->parts($name);
 
-        if (!is_string($file)) {
-            throw new \UnexpectedValueException(sprintf('Expected `$file` to be a string, got %s', gettype($file)));
+        if (!\is_string($file)) {
+            throw new \UnexpectedValueException(sprintf('Expected `$file` to be a string, got %s', \gettype($file)));
         }
 
-        if (!is_array($keys)) {
-            throw new \UnexpectedValueException(sprintf('Expected `$keys` to be a string, got %s', gettype($keys)));
+        if (!\is_array($keys)) {
+            throw new \UnexpectedValueException(sprintf('Expected `$keys` to be a string, got %s', \gettype($keys)));
         }
 
         $config = $this->load($file);
@@ -117,12 +117,12 @@ abstract class AbstractFileLoader implements FileLoaderInterface
     {
         [$file, $keys] = $this->parts($name);
 
-        if (!is_string($file)) {
-            throw new \UnexpectedValueException(sprintf('Expected `$file` to be a string, got %s', gettype($file)));
+        if (!\is_string($file)) {
+            throw new \UnexpectedValueException(sprintf('Expected `$file` to be a string, got %s', \gettype($file)));
         }
 
-        if (!is_array($keys)) {
-            throw new \UnexpectedValueException(sprintf('Expected `$keys` to be a string, got %s', gettype($keys)));
+        if (!\is_array($keys)) {
+            throw new \UnexpectedValueException(sprintf('Expected `$keys` to be a string, got %s', \gettype($keys)));
         }
 
         $config = $this->load($file);

--- a/src/Config/AbstractFileLoader.php
+++ b/src/Config/AbstractFileLoader.php
@@ -91,7 +91,7 @@ abstract class AbstractFileLoader implements FileLoaderInterface
         }
 
         if (!\is_array($keys)) {
-            throw new \UnexpectedValueException(sprintf('Expected `$keys` to be a string, got %s', \gettype($keys)));
+            throw new \UnexpectedValueException(sprintf('Expected `$keys` to be a array, got %s', \gettype($keys)));
         }
 
         $config = $this->load($file);
@@ -122,7 +122,7 @@ abstract class AbstractFileLoader implements FileLoaderInterface
         }
 
         if (!\is_array($keys)) {
-            throw new \UnexpectedValueException(sprintf('Expected `$keys` to be a string, got %s', \gettype($keys)));
+            throw new \UnexpectedValueException(sprintf('Expected `$keys` to be a array, got %s', \gettype($keys)));
         }
 
         $config = $this->load($file);

--- a/src/Config/AbstractFileLoader.php
+++ b/src/Config/AbstractFileLoader.php
@@ -10,7 +10,7 @@ abstract class AbstractFileLoader implements FileLoaderInterface
 
     public function __construct(string $path)
     {
-        $this->path = \realpath($path);
+        $this->path = realpath($path);
 
         if (false === $this->path) {
             throw new ConfigException(
@@ -29,7 +29,7 @@ abstract class AbstractFileLoader implements FileLoaderInterface
     {
         $filepath = $this->path . '/' . $name . $this->extension;
 
-        if (!\is_file($filepath)) {
+        if (!is_file($filepath)) {
             return null;
         }
 
@@ -58,7 +58,7 @@ abstract class AbstractFileLoader implements FileLoaderInterface
             );
         }
 
-        $keys = \explode('.', $name);
+        $keys = explode('.', $name);
 
         if (empty($keys)) {
             throw new ConfigException(
@@ -66,7 +66,7 @@ abstract class AbstractFileLoader implements FileLoaderInterface
             );
         }
 
-        $file = \array_shift($keys);
+        $file = array_shift($keys);
 
         if (!$file) {
             throw new ConfigException(

--- a/src/Config/AbstractFileLoader.php
+++ b/src/Config/AbstractFileLoader.php
@@ -4,25 +4,33 @@ namespace Beast\Framework\Config;
 
 abstract class AbstractFileLoader implements FileLoaderInterface
 {
+    /**
+     * @var string
+     */
     protected $path;
 
+    /**
+     * @var string
+     */
     protected $extension;
 
     public function __construct(string $path)
     {
-        $this->path = realpath($path);
+        $path = realpath($path);
 
-        if (false === $this->path) {
+        if (false === $path) {
             throw new ConfigException(
                 'Config dir not found: '.$path
             );
         }
+
+        $this->path = $path;
     }
 
     /**
      * Get the path of a config file
      *
-     * @param string
+     * @param string $name
      * @return null|string
      */
     protected function filepath(string $name): ?string
@@ -39,16 +47,16 @@ abstract class AbstractFileLoader implements FileLoaderInterface
     /**
      * Load file contents
      *
-     * @param string
-     * @return null|array
+     * @param string $file
+     * @return array<mixed>|null
      */
     abstract protected function load(string $file): ?array;
 
     /**
      * Split key into parts, the first part will always be the file name
      *
-     * @param string
-     * @return array
+     * @param string $name
+     * @return array<int, array<int, int|string>|string>
      */
     protected function parts(string $name): array
     {
@@ -59,12 +67,6 @@ abstract class AbstractFileLoader implements FileLoaderInterface
         }
 
         $keys = explode('.', $name);
-
-        if (empty($keys)) {
-            throw new ConfigException(
-                'Failed to extract keys from parameter name'
-            );
-        }
 
         $file = array_shift($keys);
 
@@ -83,6 +85,14 @@ abstract class AbstractFileLoader implements FileLoaderInterface
     public function has(string $name): bool
     {
         [$file, $keys] = $this->parts($name);
+
+        if (!is_string($file)) {
+            throw new \UnexpectedValueException(sprintf('Expected `$file` to be a string, got %s', gettype($file)));
+        }
+
+        if (!is_array($keys)) {
+            throw new \UnexpectedValueException(sprintf('Expected `$keys` to be a string, got %s', gettype($keys)));
+        }
 
         $config = $this->load($file);
 
@@ -106,6 +116,14 @@ abstract class AbstractFileLoader implements FileLoaderInterface
     public function get(string $name, $default = null)
     {
         [$file, $keys] = $this->parts($name);
+
+        if (!is_string($file)) {
+            throw new \UnexpectedValueException(sprintf('Expected `$file` to be a string, got %s', gettype($file)));
+        }
+
+        if (!is_array($keys)) {
+            throw new \UnexpectedValueException(sprintf('Expected `$keys` to be a string, got %s', gettype($keys)));
+        }
 
         $config = $this->load($file);
 

--- a/src/Config/FileLoader.php
+++ b/src/Config/FileLoader.php
@@ -23,7 +23,7 @@ class FileLoader implements FileLoaderInterface
         $reduce = function (bool $carry, FileLoaderInterface $loader) use ($name) {
             return $loader->has($name) ? true : $carry;
         };
-        return \array_reduce($this->loaders, $reduce, false);
+        return array_reduce($this->loaders, $reduce, false);
     }
 
     /**
@@ -34,6 +34,6 @@ class FileLoader implements FileLoaderInterface
         $reduce = function ($carry, FileLoaderInterface $loader) use ($name) {
             return $loader->has($name) ? $loader->get($name) : $carry;
         };
-        return \array_reduce($this->loaders, $reduce, $default);
+        return array_reduce($this->loaders, $reduce, $default);
     }
 }

--- a/src/Config/FileLoader.php
+++ b/src/Config/FileLoader.php
@@ -4,8 +4,15 @@ namespace Beast\Framework\Config;
 
 class FileLoader implements FileLoaderInterface
 {
+    /**
+     * @var array<int, FileLoaderInterface>
+     */
     protected $loaders;
 
+    /**
+     * @param string $path
+     * @param array<int, FileLoaderInterface> $loaders
+     */
     public function __construct(string $path, array $loaders = [])
     {
         $this->loaders = $loaders;

--- a/src/Config/FileLoaderInterface.php
+++ b/src/Config/FileLoaderInterface.php
@@ -7,7 +7,7 @@ interface FileLoaderInterface
     /**
      * Key exists in config file
      *
-     * @param string
+     * @param string $name
      * @return bool
      */
     public function has(string $name): bool;
@@ -15,9 +15,9 @@ interface FileLoaderInterface
     /**
      * Find key from config file
      *
-     * @param string
-     * @param mixed
-     * @return mixed
+     * @param string $name
+     * @param null|mixed $default
+     * @return null|mixed
      */
     public function get(string $name, $default = null);
 }

--- a/src/Config/JsonFileLoader.php
+++ b/src/Config/JsonFileLoader.php
@@ -27,7 +27,7 @@ class JsonFileLoader extends AbstractFileLoader
 
         $json = json_decode($jsonStr, true, 512, JSON_THROW_ON_ERROR);
 
-        if (!is_array($json)) {
+        if (!\is_array($json)) {
             throw new ConfigException(
                 'JSON config did not return an array: ' . $path
             );

--- a/src/Config/JsonFileLoader.php
+++ b/src/Config/JsonFileLoader.php
@@ -25,14 +25,14 @@ class JsonFileLoader extends AbstractFileLoader
             );
         }
 
-        $data = json_decode($jsonStr, true);
+        $json = json_decode($jsonStr, true, 512, JSON_THROW_ON_ERROR);
 
-        if (null === $data) {
+        if (!is_array($json)) {
             throw new ConfigException(
-                'json_decode error in '.$path.': ' . json_last_error_msg()
+                'JSON config did not return an array: ' . $path
             );
         }
 
-        return $data;
+        return $json;
     }
 }

--- a/src/Config/JsonFileLoader.php
+++ b/src/Config/JsonFileLoader.php
@@ -17,7 +17,7 @@ class JsonFileLoader extends AbstractFileLoader
             return null;
         }
 
-        $jsonStr = \file_get_contents($path);
+        $jsonStr = file_get_contents($path);
 
         if (false === $jsonStr) {
             throw new ConfigException(
@@ -25,11 +25,11 @@ class JsonFileLoader extends AbstractFileLoader
             );
         }
 
-        $data = \json_decode($jsonStr, true);
+        $data = json_decode($jsonStr, true);
 
         if (null === $data) {
             throw new ConfigException(
-                'json_decode error in '.$path.': ' . \json_last_error_msg()
+                'json_decode error in '.$path.': ' . json_last_error_msg()
             );
         }
 

--- a/src/Config/PhpFileLoader.php
+++ b/src/Config/PhpFileLoader.php
@@ -4,6 +4,9 @@ namespace Beast\Framework\Config;
 
 class PhpFileLoader extends AbstractFileLoader
 {
+    /**
+     * @var string
+     */
     protected $extension = '.php';
 
     /**

--- a/src/Database/AggregationTrait.php
+++ b/src/Database/AggregationTrait.php
@@ -42,14 +42,14 @@ trait AggregationTrait
         $newQuery = null === $query ? $this->getQueryBuilder() : clone $query;
 
         if (null === $column) {
-            $column = \sprintf(
+            $column = sprintf(
                 '%s.%s',
                 $this->getConnection()->quoteIdentifier($this->table),
                 $this->getConnection()->quoteIdentifier($this->primary)
             );
         }
 
-        $newQuery->select(\sprintf('%s(%s)', $method, $column));
+        $newQuery->select(sprintf('%s(%s)', $method, $column));
 
         $value = $this->column($newQuery);
 

--- a/src/Database/AggregationTrait.php
+++ b/src/Database/AggregationTrait.php
@@ -24,17 +24,17 @@ trait AggregationTrait
     /**
      * Fetch the first column from the first row of a query
      *
-     * @param QueryBuilder
-     * @return mixed
+     * @param QueryBuilder|null $query
+     * @return string|int|null|boolean
      */
     abstract public function column(QueryBuilder $query = null);
 
     /**
      * Run a aggregate function against a column
      *
-     * @param string
-     * @param string
-     * @param QueryBuilder
+     * @param string $method
+     * @param string|null $column
+     * @param QueryBuilder|null $query
      * @return string
      */
     private function aggregate(string $method, string $column = null, QueryBuilder $query = null): string
@@ -58,14 +58,18 @@ trait AggregationTrait
             return '0';
         }
 
-        return $value;
+        if (is_numeric($value)) {
+            return (string) $value;
+        }
+
+        throw new \UnexpectedValueException('`column` did not return a numeric-string or integer');
     }
 
     /**
      * Run count aggregate
      *
-     * @param QueryBuilder
-     * @param string|null
+     * @param QueryBuilder|null $query
+     * @param string|null $column
      * @return string
      */
     public function count(QueryBuilder $query = null, string $column = null): string
@@ -76,8 +80,8 @@ trait AggregationTrait
     /**
      * Run sum aggregate
      *
-     * @param QueryBuilder
-     * @param string|null
+     * @param QueryBuilder|null $query
+     * @param string|null $column
      * @return string
      */
     public function sum(QueryBuilder $query = null, string $column = null): string
@@ -88,8 +92,8 @@ trait AggregationTrait
     /**
      * Run min aggregate
      *
-     * @param QueryBuilder
-     * @param string|null
+     * @param QueryBuilder|null $query
+     * @param string|null $column
      * @return string
      */
     public function min(QueryBuilder $query = null, string $column = null): string
@@ -100,8 +104,8 @@ trait AggregationTrait
     /**
      * Run max aggregate
      *
-     * @param QueryBuilder
-     * @param string|null
+     * @param QueryBuilder|null $query
+     * @param string|null $column
      * @return string
      */
     public function max(QueryBuilder $query = null, string $column = null): string

--- a/src/Database/Entity.php
+++ b/src/Database/Entity.php
@@ -7,15 +7,28 @@ use RuntimeException;
 
 abstract class Entity implements EntityInterface
 {
+    /**
+     * @var array<string, int|string|null>
+     */
     protected $attributes = [];
 
+    /**
+     * @var array<int, string>
+     */
     protected $guarded = [];
 
+    /**
+     * @param array<string, int|string|null> $attributes
+     */
     public function __construct(array $attributes = [])
     {
         $this->setAttributes($attributes);
     }
 
+    /**
+     * @param  string $key
+     * @return int|string|null
+     */
     public function __get(string $key)
     {
         if (!\array_key_exists($key, $this->attributes)) {
@@ -24,6 +37,10 @@ abstract class Entity implements EntityInterface
         return $this->attributes[$key];
     }
 
+    /**
+     * @param string $key
+     * @param int|string|null $value
+     */
     public function __set(string $key, $value): void
     {
         $this->attributes[$key] = $value;
@@ -41,6 +58,10 @@ abstract class Entity implements EntityInterface
         }
     }
 
+    /**
+     * @param  array<string, int|string|null> $attributes
+     * @return EntityInterface
+     */
     public function withAttributes(array $attributes): EntityInterface
     {
         $this->setAttributes($attributes);
@@ -48,16 +69,26 @@ abstract class Entity implements EntityInterface
         return $this;
     }
 
+    /**
+     * @param array<string, int|string|null> $attributes
+     * @return void
+     */
     public function setAttributes(array $attributes): void
     {
         $this->attributes = $attributes;
     }
 
+    /**
+     * @return array<string, int|string|null>
+     */
     public function getAttributes(): array
     {
         return $this->attributes;
     }
 
+    /**
+     * @return array<string, int|string|null>
+     */
     public function toArray(): array
     {
         return array_diff_key($this->getAttributes(), array_flip($this->guarded));

--- a/src/Database/Entity.php
+++ b/src/Database/Entity.php
@@ -19,7 +19,7 @@ abstract class Entity implements EntityInterface
     public function __get(string $key)
     {
         if (!\array_key_exists($key, $this->attributes)) {
-            throw new ErrorException(\sprintf('Undefined attribute "%s" on %s', $key, \get_class($this)));
+            throw new ErrorException(sprintf('Undefined attribute "%s" on %s', $key, \get_class($this)));
         }
         return $this->attributes[$key];
     }
@@ -60,16 +60,16 @@ abstract class Entity implements EntityInterface
 
     public function toArray(): array
     {
-        return \array_diff_key($this->getAttributes(), \array_flip($this->guarded));
+        return array_diff_key($this->getAttributes(), array_flip($this->guarded));
     }
 
     public function toJson(): string
     {
-        $encoded = \json_encode($this->toArray());
+        $encoded = json_encode($this->toArray());
 
         if (false === $encoded) {
             throw new RuntimeException(
-                'json_encode error: ' . \json_last_error_msg()
+                'json_encode error: ' . json_last_error_msg()
             );
         }
 

--- a/src/Database/EntityInterface.php
+++ b/src/Database/EntityInterface.php
@@ -4,12 +4,26 @@ namespace Beast\Framework\Database;
 
 interface EntityInterface
 {
+    /**
+     * @param  array<string, int|string|null> $attributes
+     * @return EntityInterface
+     */
     public function withAttributes(array $attributes): EntityInterface;
 
-    public function setAttributes(array $attributes);
+    /**
+     * @param  array<string, int|string|null> $attributes
+     * @return void
+     */
+    public function setAttributes(array $attributes): void;
 
+    /**
+     * @return array<string, int|string|null> 
+     */
     public function getAttributes(): array;
 
+    /**
+     * @return array<string, int|string|null> 
+     */
     public function toArray(): array;
 
     public function toJson(): string;

--- a/src/Database/EntityInterface.php
+++ b/src/Database/EntityInterface.php
@@ -17,12 +17,12 @@ interface EntityInterface
     public function setAttributes(array $attributes): void;
 
     /**
-     * @return array<string, int|string|null> 
+     * @return array<string, int|string|null>
      */
     public function getAttributes(): array;
 
     /**
-     * @return array<string, int|string|null> 
+     * @return array<string, int|string|null>
      */
     public function toArray(): array;
 

--- a/src/Database/TableGateway.php
+++ b/src/Database/TableGateway.php
@@ -52,8 +52,7 @@ abstract class TableGateway
 
         // create anon object class to create rows from
         if ($prototype === null) {
-            $prototype = new class extends Entity {
-            };
+            $prototype = new class extends Entity {};
         }
 
         if (!$prototype instanceof EntityInterface) {
@@ -131,7 +130,7 @@ abstract class TableGateway
      * Execute a query against this table gateway
      *
      * @param QueryBuilder $query
-     * @return \Doctrine\DBAL\ForwardCompatibility\DriverStatement|\Doctrine\DBAL\ForwardCompatibility\DriverResultStatement
+     * @return \Doctrine\DBAL\ForwardCompatibility\DriverStatement<int, array<string, int|string|null>>|\Doctrine\DBAL\ForwardCompatibility\DriverResultStatement<int, array<string, int|string|null>>
      * @throws TableGatewayException
      */
     protected function execute(QueryBuilder $query)
@@ -146,7 +145,7 @@ abstract class TableGateway
     /**
      * Create a model entity from database row
      *
-     * @param array<string, mixed> $attributes
+     * @param array<string, int|string|null> $attributes
      * @return EntityInterface
      */
     protected function model(array $attributes): EntityInterface
@@ -168,7 +167,10 @@ abstract class TableGateway
 
         $statement = $this->execute($query);
 
-        if ($row = $statement->fetchAssociative()) {
+        /** @var array<string, int|string|null> $row */
+        $row = $statement->fetchAssociative();
+
+        if ($row) {
             return $this->model($row);
         }
 

--- a/src/Database/TableGateway.php
+++ b/src/Database/TableGateway.php
@@ -52,7 +52,8 @@ abstract class TableGateway
 
         // create anon object class to create rows from
         if ($prototype === null) {
-            $prototype = new class extends Entity {};
+            $prototype = new class extends Entity {
+            };
         }
 
         if (!$prototype instanceof EntityInterface) {

--- a/src/Database/TableGateway.php
+++ b/src/Database/TableGateway.php
@@ -59,14 +59,14 @@ abstract class TableGateway
         $this->prototype = $prototype;
 
         if (empty($this->table)) {
-            throw new TableGatewayException(\sprintf(
+            throw new TableGatewayException(sprintf(
                 'The property "table" must be set on class %s',
                 \get_class($this)
             ));
         }
 
         if (empty($this->primary)) {
-            throw new TableGatewayException(\sprintf(
+            throw new TableGatewayException(sprintf(
                 'The property "primary" must be set on class %s',
                 \get_class($this)
             ));
@@ -193,12 +193,12 @@ abstract class TableGateway
      */
     protected function toBytes(string $string): int
     {
-        \sscanf($string, '%u%c', $number, $suffix);
+        sscanf($string, '%u%c', $number, $suffix);
 
         if (isset($suffix)) {
-            $exp = \strpos(' KMG', \strtoupper($suffix));
+            $exp = strpos(' KMG', strtoupper($suffix));
             if (false !== $exp) {
-                $number = $number * \pow(1024, $exp);
+                $number = $number * pow(1024, $exp);
             }
         }
 
@@ -223,14 +223,14 @@ abstract class TableGateway
         // when buffering results into array
         // check memory usage to prevent fatal error
         $limit = $this->getMemoryLimit();
-        $current = \memory_get_usage();
+        $current = memory_get_usage();
         $max = $limit - $current;
 
         foreach ($statement as $row) {
             $results[] = $this->model($row);
-            $usage = \memory_get_usage();
+            $usage = memory_get_usage();
             if ($usage > $max) {
-                throw new \OverflowException(\sprintf('Allowed memory size of %s bytes has been exceeded', $max));
+                throw new \OverflowException(sprintf('Allowed memory size of %s bytes has been exceeded', $max));
             }
         }
 

--- a/src/Http/EmitterInterface.php
+++ b/src/Http/EmitterInterface.php
@@ -24,5 +24,5 @@ interface EmitterInterface
      *
      * @param ResponseInterface $response
      */
-    public function emit(ResponseInterface $response);
+    public function emit(ResponseInterface $response): void;
 }

--- a/src/Http/Middlewares/Csrf.php
+++ b/src/Http/Middlewares/Csrf.php
@@ -70,7 +70,7 @@ class Csrf implements MiddlewareInterface
 
         $input = $request->getParsedBody();
 
-        if (is_array($input) && isset($input[$this->inputFieldName])) {
+        if (\is_array($input) && isset($input[$this->inputFieldName])) {
             return $input[$this->inputFieldName];
         }
 

--- a/src/Http/Middlewares/Csrf.php
+++ b/src/Http/Middlewares/Csrf.php
@@ -62,7 +62,7 @@ class Csrf implements MiddlewareInterface
             return $input[$this->inputFieldName];
         }
 
-        throw new InvalidArgumentException(\sprintf(
+        throw new InvalidArgumentException(sprintf(
             'Csrf token not found in %s header or %s body',
             $this->headerFieldName,
             $this->inputFieldName

--- a/src/Http/Middlewares/Csrf.php
+++ b/src/Http/Middlewares/Csrf.php
@@ -14,12 +14,24 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 class Csrf implements MiddlewareInterface
 {
+    /**
+     * @var ResponseInterface
+     */
     protected $response;
 
+    /**
+     * @var StorageInterface
+     */
     protected $storage;
 
+    /**
+     * @var string
+     */
     protected $inputFieldName;
 
+    /**
+     * @var string
+     */
     protected $headerFieldName;
 
     public function __construct(
@@ -40,7 +52,7 @@ class Csrf implements MiddlewareInterface
             'POST',
             'PUT',
             'PATCH',
-        ]);
+        ], true);
     }
 
     protected function isValid(ServerRequestInterface $request): bool
@@ -58,7 +70,7 @@ class Csrf implements MiddlewareInterface
 
         $input = $request->getParsedBody();
 
-        if (isset($input[$this->inputFieldName])) {
+        if (is_array($input) && isset($input[$this->inputFieldName])) {
             return $input[$this->inputFieldName];
         }
 
@@ -71,7 +83,7 @@ class Csrf implements MiddlewareInterface
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        if (! $this->isMethod($request) || ($this->isMethod($request) && $this->isValid($request))) {
+        if ($this->isMethod($request) && $this->isValid($request)) {
             return $handler->handle($request);
         }
 

--- a/src/Http/Middlewares/Kernel.php
+++ b/src/Http/Middlewares/Kernel.php
@@ -13,8 +13,14 @@ use Psr\Http\Server\RequestHandlerInterface;
 
 class Kernel implements MiddlewareInterface
 {
+    /**
+     * @var Routes
+     */
     private $routes;
 
+    /**
+     * @var ResolverInterface
+     */
     private $resolver;
 
     public function __construct(Routes $routes, ResolverInterface $resolver)

--- a/src/Http/Resolver.php
+++ b/src/Http/Resolver.php
@@ -29,7 +29,7 @@ class Resolver implements ResolverInterface
         $controller = $route->getController();
 
         // Single Action Controllers (Invokable Controllers)
-        if (is_string($controller) && class_exists($controller)) {
+        if (\is_string($controller) && \class_exists($controller)) {
             $instance = $this->container->get($controller);
 
             if ($instance instanceof ContainerAwareInterface) {
@@ -51,22 +51,10 @@ class Resolver implements ResolverInterface
             return $instance->$method($request, $response, $route->getParams());
         }
 
-        if (\is_string($controller) && \strpos($controller, '@')) {
-            [$class, $method] = \explode('@', $controller, 2);
-
-            $instance = $this->container->get($class);
-
-            if ($instance instanceof ContainerAwareInterface) {
-                $instance->setContainer($this->container);
-            }
-
-            return $instance->$method($request, $response, $route->getParams());
-        }
-
         if ($controller instanceof Closure) {
             return $controller->bindTo($this->container)($request, $response, $route->getParams());
         }
 
-        throw new InvalidArgumentException('controller must be a Closure, array or string');
+        throw new InvalidArgumentException('controller must be a Closure, array or class-string');
     }
 }

--- a/src/Http/Resolver.php
+++ b/src/Http/Resolver.php
@@ -39,7 +39,7 @@ class Resolver implements ResolverInterface
                 $instance->setContainer($this->container);
             }
 
-            if (is_callable($instance)) {
+            if (\is_callable($instance)) {
                 return $instance($request, $response, $route->getParams());
             }
         }

--- a/src/Http/Resolver.php
+++ b/src/Http/Resolver.php
@@ -14,6 +14,9 @@ use Psr\Http\Message\ServerRequestInterface;
 
 class Resolver implements ResolverInterface
 {
+    /**
+     * @var ContainerInterface
+     */
     protected $container;
 
     public function __construct(ContainerInterface $container)
@@ -36,7 +39,9 @@ class Resolver implements ResolverInterface
                 $instance->setContainer($this->container);
             }
 
-            return $instance($request, $response, $route->getParams());
+            if (is_callable($instance)) {
+                return $instance($request, $response, $route->getParams());
+            }
         }
 
         if (\is_array($controller) && \count($controller) === 2) {
@@ -52,7 +57,10 @@ class Resolver implements ResolverInterface
         }
 
         if ($controller instanceof Closure) {
-            return $controller->bindTo($this->container)($request, $response, $route->getParams());
+            $closure = $controller->bindTo($this->container);
+            if ($closure !== null) {
+                return $closure($request, $response, $route->getParams());
+            }
         }
 
         throw new InvalidArgumentException('controller must be a Closure, array or class-string');

--- a/src/Http/Resolver.php
+++ b/src/Http/Resolver.php
@@ -29,7 +29,7 @@ class Resolver implements ResolverInterface
         $controller = $route->getController();
 
         // Single Action Controllers (Invokable Controllers)
-        if (\is_string($controller) && \class_exists($controller)) {
+        if (\is_string($controller) && class_exists($controller)) {
             $instance = $this->container->get($controller);
 
             if ($instance instanceof ContainerAwareInterface) {

--- a/src/Http/SapiEmitter.php
+++ b/src/Http/SapiEmitter.php
@@ -82,6 +82,7 @@ class SapiEmitter implements EmitterInterface
      * the response body using `echo()`.
      *
      * @param ResponseInterface $response
+     * @param null|int $maxBufferLevel Maximum output buffering level to unwrap.
      */
     private function emitBody(ResponseInterface $response, $maxBufferLevel): void
     {

--- a/src/Http/SapiEmitter.php
+++ b/src/Http/SapiEmitter.php
@@ -21,7 +21,7 @@ class SapiEmitter implements EmitterInterface
      */
     public function emit(ResponseInterface $response, $maxBufferLevel = null): void
     {
-        if (\headers_sent()) {
+        if (headers_sent()) {
             throw new RuntimeException('Unable to emit response; headers already sent');
         }
 
@@ -41,7 +41,7 @@ class SapiEmitter implements EmitterInterface
     private function emitStatusLine(ResponseInterface $response): void
     {
         $reasonPhrase = $response->getReasonPhrase();
-        \header(\sprintf(
+        header(sprintf(
             'HTTP/%s %d%s',
             $response->getProtocolVersion(),
             $response->getStatusCode(),
@@ -65,7 +65,7 @@ class SapiEmitter implements EmitterInterface
             $name  = $this->filterHeader($header);
             $first = true;
             foreach ($values as $value) {
-                \header(\sprintf(
+                header(sprintf(
                     '%s: %s',
                     $name,
                     $value
@@ -86,11 +86,11 @@ class SapiEmitter implements EmitterInterface
     private function emitBody(ResponseInterface $response, $maxBufferLevel): void
     {
         if (null === $maxBufferLevel) {
-            $maxBufferLevel = \ob_get_level();
+            $maxBufferLevel = ob_get_level();
         }
 
-        while (\ob_get_level() > $maxBufferLevel) {
-            \ob_end_flush();
+        while (ob_get_level() > $maxBufferLevel) {
+            ob_end_flush();
         }
 
         echo $response->getBody();
@@ -104,8 +104,8 @@ class SapiEmitter implements EmitterInterface
      */
     private function filterHeader($header)
     {
-        $filtered = \str_replace('-', ' ', $header);
-        $filtered = \ucwords($filtered);
-        return \str_replace(' ', '-', $filtered);
+        $filtered = str_replace('-', ' ', $header);
+        $filtered = ucwords($filtered);
+        return str_replace(' ', '-', $filtered);
     }
 }

--- a/src/Router/Route.php
+++ b/src/Router/Route.php
@@ -44,7 +44,7 @@ class Route
     protected $controller;
 
     /**
-     * @var array<string, int|string>
+     * @var array<int|string, mixed>
      */
     protected $params = [];
 
@@ -62,7 +62,7 @@ class Route
     }
 
     /**
-     * @return array<string, int|string|array<mixed>>
+     * @return array<int|string, mixed>
      */
     public function getParams(): array
     {
@@ -139,11 +139,15 @@ class Route
 
         list($path, $tokens) = $this->tokenise();
 
-        if (! preg_match('~^'.$path.'$~', $url, $matches)) {
+        if (\is_string($path) && ! preg_match('~^'.$path.'$~', $url, $matches)) {
             return false;
         }
 
-        if (!is_array($matches)) {
+        if (!isset($matches) || !\is_array($matches)) {
+            return false;
+        }
+
+        if (!\is_array($tokens)) {
             return false;
         }
 

--- a/src/Router/Route.php
+++ b/src/Router/Route.php
@@ -51,7 +51,7 @@ class Route
 
     public function setPath(string $path)
     {
-        $this->path = \rtrim($path, '/') ?: '/';
+        $this->path = rtrim($path, '/') ?: '/';
 
         return $this;
     }
@@ -75,7 +75,7 @@ class Route
 
     public function setMethod($method)
     {
-        $this->method = \strtoupper($method);
+        $this->method = strtoupper($method);
 
         return $this;
     }
@@ -104,11 +104,11 @@ class Route
 
         list($path, $tokens) = $this->tokenise();
 
-        if (! \preg_match('~^'.$path.'$~', $url, $matches)) {
+        if (! preg_match('~^'.$path.'$~', $url, $matches)) {
             return false;
         }
 
-        $this->params = \array_combine($tokens, \array_slice($matches, 1));
+        $this->params = array_combine($tokens, \array_slice($matches, 1));
 
         return true;
     }

--- a/src/Router/Route.php
+++ b/src/Router/Route.php
@@ -44,7 +44,7 @@ class Route
     protected $controller;
 
     /**
-     * @var array<int|string, mixed>
+     * @var array<int|string, mixed>|false
      */
     protected $params = [];
 
@@ -62,9 +62,9 @@ class Route
     }
 
     /**
-     * @return array<int|string, mixed>
+     * @return array<int|string, mixed>|false
      */
-    public function getParams(): array
+    public function getParams()
     {
         return $this->params;
     }

--- a/src/Router/Route.php
+++ b/src/Router/Route.php
@@ -61,11 +61,18 @@ class Route
         $this->params = [];
     }
 
+    /**
+     * @return array<string, int|string|array<mixed>>
+     */
     public function getParams(): array
     {
         return $this->params;
     }
 
+    /**
+     * @param string $path
+     * @return self
+     */
     public function setPath(string $path)
     {
         $this->path = rtrim($path, '/') ?: '/';
@@ -78,6 +85,10 @@ class Route
         return $this->path;
     }
 
+    /**
+     * @param class-string|callable(\Psr\Http\Message\ServerRequestInterface, \Psr\Http\Message\ResponseInterface, array<string, int|string|array<mixed>>): void|non-empty-array<class-string, string> $controller
+     * @return self
+     */
     public function setController($controller)
     {
         $this->controller = $controller;
@@ -85,12 +96,19 @@ class Route
         return $this;
     }
 
+    /**
+     * @return class-string|callable(\Psr\Http\Message\ServerRequestInterface, \Psr\Http\Message\ResponseInterface, array<string, int|string|array<mixed>>): void|non-empty-array<class-string, string>
+     */
     public function getController()
     {
         return $this->controller;
     }
 
-    public function setMethod($method)
+    /**
+     * @param string $method
+     * @return self
+     */
+    public function setMethod(string $method)
     {
         $this->method = strtoupper($method);
 
@@ -122,6 +140,10 @@ class Route
         list($path, $tokens) = $this->tokenise();
 
         if (! preg_match('~^'.$path.'$~', $url, $matches)) {
+            return false;
+        }
+
+        if (!is_array($matches)) {
             return false;
         }
 

--- a/src/Router/Route.php
+++ b/src/Router/Route.php
@@ -28,14 +28,31 @@ class Route
 
     public const METHOD_DELETE = 'DELETE';
 
+    /**
+     * @var string
+     */
     protected $method;
 
+    /**
+     * @var string
+     */
     protected $path;
 
+    /**
+     * @var class-string|callable(\Psr\Http\Message\ServerRequestInterface, \Psr\Http\Message\ResponseInterface, array<string, int|string|array<mixed>>): void|non-empty-array<class-string, string>
+     */
     protected $controller;
 
-    protected $params;
+    /**
+     * @var array<string, int|string>
+     */
+    protected $params = [];
 
+    /**
+     * @param string $method
+     * @param string $path
+     * @param class-string|callable(\Psr\Http\Message\ServerRequestInterface, \Psr\Http\Message\ResponseInterface, array<string, int|string|array<mixed>>): void|non-empty-array<class-string, string> $controller
+     */
     public function __construct(string $method, string $path, $controller)
     {
         $this->setMethod($method);

--- a/src/Router/RouteTokensTrait.php
+++ b/src/Router/RouteTokensTrait.php
@@ -20,7 +20,7 @@ trait RouteTokensTrait
     }
 
     /**
-     * @return array<int, mixed>
+     * @return array<int, bool|float|int|string|array<int|string>>
      */
     protected function tokenise(): array
     {

--- a/src/Router/RouteTokensTrait.php
+++ b/src/Router/RouteTokensTrait.php
@@ -19,6 +19,9 @@ trait RouteTokensTrait
             strpos($path, '[') !== false;
     }
 
+    /**
+     * @return array<int, mixed>
+     */
     protected function tokenise(): array
     {
         $pattern = '~\{([A-z0-9\-_]+)(:([A-z0-9",\-_\*]+))?\}~';
@@ -39,6 +42,11 @@ trait RouteTokensTrait
         throw new RuntimeException('No tokens found');
     }
 
+    /**
+     * @param  array<int, array<int, string>> $matches
+     * @param  string $path
+     * @return string
+     */
     protected function parameterise(array $matches, string $path): string
     {
         $pattern = function ($token): string {

--- a/src/Router/RouteTokensTrait.php
+++ b/src/Router/RouteTokensTrait.php
@@ -12,18 +12,18 @@ trait RouteTokensTrait
     {
         $path = $this->getPath();
         // contains tokens
-        return \strpos($path, '{') !== false ||
+        return strpos($path, '{') !== false ||
             // contains captures
-            \strpos($path, '(') !== false ||
+            strpos($path, '(') !== false ||
             // contains groups
-            \strpos($path, '[') !== false;
+            strpos($path, '[') !== false;
     }
 
     protected function tokenise(): array
     {
         $pattern = '~\{([A-z0-9\-_]+)(:([A-z0-9",\-_\*]+))?\}~';
 
-        if (\preg_match_all($pattern, $this->getPath(), $matches)) {
+        if (preg_match_all($pattern, $this->getPath(), $matches)) {
             // named parameters to combine when matched with a URL
             $tokens = $matches[1];
 
@@ -55,8 +55,8 @@ trait RouteTokensTrait
             }
 
             // enum pattern "option1,option2"
-            if (\preg_match('~"([^"]+)"~', $token, $match)) {
-                $options = \implode('|', \explode(',', $match[1]));
+            if (preg_match('~"([^"]+)"~', $token, $match)) {
+                $options = implode('|', explode(',', $match[1]));
                 return '('.$options.')';
             }
 
@@ -65,7 +65,7 @@ trait RouteTokensTrait
         };
 
         foreach ($matches[0] as $index => $search) {
-            $path = \str_replace($search, $pattern($matches[3][$index]), $path);
+            $path = str_replace($search, $pattern($matches[3][$index]), $path);
         }
 
         return $path;

--- a/src/Router/Routes.php
+++ b/src/Router/Routes.php
@@ -14,24 +14,22 @@ use SplObjectStorage;
  * Class Routes
  *
  * @package Beast\Framework\Router
- * @method Route any(string $path, array|Closure|string $args)
- * @method Route connect(string $path, array|Closure|string $args)
- * @method Route trace(string $path, array|Closure|string $args)
- * @method Route get(string $path, array|Closure|string $args)
- * @method Route head(string $path, array|Closure|string $args)
- * @method Route options(string $path, array|Closure|string $args)
- * @method Route post(string $path, array|Closure|string $args)
- * @method Route put(string $path, array|Closure|string $args)
- * @method Route patch(string $path, array|Closure|string $args)
- * @method Route delete(string $path, array|Closure|string $args)
+ * @method Route any(string $path, array|Closure|class-string $args)
+ * @method Route connect(string $path, array|Closure|class-string $args)
+ * @method Route trace(string $path, array|Closure|class-string $args)
+ * @method Route get(string $path, array|Closure|class-string $args)
+ * @method Route head(string $path, array|Closure|class-string $args)
+ * @method Route options(string $path, array|Closure|class-string $args)
+ * @method Route post(string $path, array|Closure|class-string $args)
+ * @method Route put(string $path, array|Closure|class-string $args)
+ * @method Route patch(string $path, array|Closure|class-string $args)
+ * @method Route delete(string $path, array|Closure|class-string $args)
  */
 class Routes implements Countable, IteratorAggregate
 {
     protected $routes;
 
     protected $segments;
-
-    protected $namespaces;
 
     public function __construct(array $routes = [])
     {
@@ -40,7 +38,6 @@ class Routes implements Countable, IteratorAggregate
             $this->append($route);
         }
         $this->segments = [];
-        $this->namespaces = [];
     }
 
     public function getIterator(): Iterator
@@ -58,20 +55,12 @@ class Routes implements Countable, IteratorAggregate
         if (isset($options['prefix'])) {
             $this->segments[] = \rtrim($options['prefix'], '/');
         }
-
-        if (isset($options['namespace'])) {
-            $this->namespaces[] = '\\'.$options['namespace'];
-        }
     }
 
     public function removeOptions(array $options): void
     {
         if (isset($options['prefix'])) {
             \array_pop($this->segments);
-        }
-
-        if (isset($options['namespace'])) {
-            \array_pop($this->namespaces);
         }
     }
 
@@ -89,22 +78,25 @@ class Routes implements Countable, IteratorAggregate
         return \implode('', $this->segments);
     }
 
-    public function getNamespace(): string
-    {
-        return \implode('', $this->namespaces) . '\\';
-    }
-
     public function append(Route $route): void
     {
         $this->routes->attach($route);
     }
 
+    /**
+     * Create a new Route Definition
+     * 
+     * @param  string $method
+     * @param  string $path
+     * @param  array|Closure|class-string $controller
+     * @return Route
+     */
     public function create(string $method, string $path, $controller): Route
     {
         return new Route(
             $method,
             $this->getPrefix().$path,
-            \is_string($controller) ? $this->getNamespace().$controller : $controller
+            $controller
         );
     }
 

--- a/src/Router/Routes.php
+++ b/src/Router/Routes.php
@@ -53,14 +53,14 @@ class Routes implements Countable, IteratorAggregate
     public function addOptions(array $options): void
     {
         if (isset($options['prefix'])) {
-            $this->segments[] = \rtrim($options['prefix'], '/');
+            $this->segments[] = rtrim($options['prefix'], '/');
         }
     }
 
     public function removeOptions(array $options): void
     {
         if (isset($options['prefix'])) {
-            \array_pop($this->segments);
+            array_pop($this->segments);
         }
     }
 
@@ -75,7 +75,7 @@ class Routes implements Countable, IteratorAggregate
 
     public function getPrefix(): string
     {
-        return \implode('', $this->segments);
+        return implode('', $this->segments);
     }
 
     public function append(Route $route): void
@@ -85,7 +85,7 @@ class Routes implements Countable, IteratorAggregate
 
     /**
      * Create a new Route Definition
-     * 
+     *
      * @param  string $method
      * @param  string $path
      * @param  array|Closure|class-string $controller
@@ -102,7 +102,7 @@ class Routes implements Countable, IteratorAggregate
 
     public function __call(string $method, array $args): Route
     {
-        $method = \strtoupper($method);
+        $method = strtoupper($method);
 
         $allowed = [
             Route::METHOD_ANY,

--- a/src/Router/Routes.php
+++ b/src/Router/Routes.php
@@ -2,7 +2,6 @@
 
 namespace Beast\Framework\Router;
 
-use BadMethodCallException;
 use Countable;
 use Iterator;
 use IteratorAggregate;

--- a/src/Support/ContainerAwareInterface.php
+++ b/src/Support/ContainerAwareInterface.php
@@ -6,7 +6,7 @@ use Psr\Container\ContainerInterface;
 
 interface ContainerAwareInterface
 {
-    public function setContainer(ContainerInterface $container);
+    public function setContainer(ContainerInterface $container): void;
 
     public function getContainer(): ContainerInterface;
 }

--- a/src/Support/Paths.php
+++ b/src/Support/Paths.php
@@ -10,7 +10,7 @@ class Paths
 
     public function __construct(string $path)
     {
-        $this->path = \realpath($path);
+        $this->path = realpath($path);
 
         if (false === $this->path) {
             throw new InvalidArgumentException(

--- a/src/Support/Paths.php
+++ b/src/Support/Paths.php
@@ -6,17 +6,22 @@ use InvalidArgumentException;
 
 class Paths
 {
+    /**
+     * @var string
+     */
     protected $path;
 
     public function __construct(string $path)
     {
-        $this->path = realpath($path);
+        $path = realpath($path);
 
-        if (false === $this->path) {
+        if (false === $path) {
             throw new InvalidArgumentException(
                 'Path dir not found: '.$path
             );
         }
+
+        $this->path = $path;
     }
 
     public function resolve(string $relative): string

--- a/src/Tokens/Generator.php
+++ b/src/Tokens/Generator.php
@@ -4,12 +4,6 @@ namespace Beast\Framework\Tokens;
 
 class Generator
 {
-    /**
-     * Create a token
-     *
-     * @param int
-     * @return string
-     */
     public function create(int $size = 32): string
     {
         $bytes = random_bytes($size);

--- a/src/Tokens/Generator.php
+++ b/src/Tokens/Generator.php
@@ -4,6 +4,10 @@ namespace Beast\Framework\Tokens;
 
 class Generator
 {
+    /**
+     * @param  int<1, max> $size
+     * @return string
+     */
     public function create(int $size = 32): string
     {
         $bytes = random_bytes($size);

--- a/src/Tokens/Generator.php
+++ b/src/Tokens/Generator.php
@@ -12,8 +12,8 @@ class Generator
      */
     public function create(int $size = 32): string
     {
-        $bytes = \random_bytes($size);
+        $bytes = random_bytes($size);
 
-        return \bin2hex($bytes);
+        return bin2hex($bytes);
     }
 }

--- a/src/Tokens/RedisStorage.php
+++ b/src/Tokens/RedisStorage.php
@@ -4,8 +4,14 @@ namespace Beast\Framework\Tokens;
 
 class RedisStorage implements StorageInterface
 {
+    /**
+     * @var \Redis
+     */
     protected $redis;
 
+    /**
+     * @var string
+     */
     protected $channel;
 
     public function __construct(\Redis $redis, string $channel = 'csrf_tokens')

--- a/src/Tokens/StorageInterface.php
+++ b/src/Tokens/StorageInterface.php
@@ -8,5 +8,5 @@ interface StorageInterface
 
     public function validate(string $token): bool;
 
-    public function put(string $token);
+    public function put(string $token): bool;
 }

--- a/tests/ConfigJsonTest.php
+++ b/tests/ConfigJsonTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests;
+namespace Beast\Framework\Tests;
 
 use Beast\Framework\Config\ConfigException;
 use Beast\Framework\Config\JsonFileLoader as FileLoader;

--- a/tests/ConfigPhpTest.php
+++ b/tests/ConfigPhpTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests;
+namespace Beast\Framework\Tests;
 
 use Beast\Framework\Config\ConfigException;
 use Beast\Framework\Config\PhpFileLoader as FileLoader;

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests;
+namespace Beast\Framework\Tests;
 
 use Beast\Framework\Config\FileLoader;
 use PHPUnit\Framework\TestCase;

--- a/tests/CsrfTest.php
+++ b/tests/CsrfTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests;
+namespace Beast\Framework\Tests;
 
 use Beast\Framework\Http\Middlewares\Csrf;
 

--- a/tests/EntityTest.php
+++ b/tests/EntityTest.php
@@ -86,7 +86,7 @@ class EntityTest extends TestCase
 
     public function testEntityToJsonException(): void
     {
-        $entity = new class(['random_bytes' => \random_bytes(4)]) extends Entity {
+        $entity = new class(['random_bytes' => random_bytes(4)]) extends Entity {
         };
 
         $this->expectException(RuntimeException::class);

--- a/tests/EntityTest.php
+++ b/tests/EntityTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests;
+namespace Beast\Framework\Tests;
 
 use Beast\Framework\Database\Entity;
 use ErrorException;

--- a/tests/Fixtures/ExampleController.php
+++ b/tests/Fixtures/ExampleController.php
@@ -13,4 +13,9 @@ class ExampleController
 
         return $response;
     }
+
+    public function index(ServerRequestInterface $request, ResponseInterface $response)
+    {
+        return $this->__invoke($request, $response);
+    }
 }

--- a/tests/GeneratorTest.php
+++ b/tests/GeneratorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests;
+namespace Beast\Framework\Tests;
 
 use Beast\Framework\Tokens\Generator;
 use PHPUnit\Framework\TestCase;

--- a/tests/Http/ResolverTest.php
+++ b/tests/Http/ResolverTest.php
@@ -13,13 +13,17 @@ use Psr\Http\Message\StreamInterface;
 
 class ResolverTest extends TestCase
 {
-    public function testResolvesToSingleActionController(): void
+    /**
+     * @dataProvider routeDataProvider
+     * @param  Route $route
+     * @return void
+     */
+    public function testResolvesToSingleActionController(Route $route): void
     {
         $containerMock = $this->createMock(ContainerInterface::class);
         $requestMock = $this->createMock(ServerRequestInterface::class);
         $responseMock = $this->createMock(ResponseInterface::class);
         $streamMock = $this->createMock(StreamInterface::class);
-        $route = new Route('GET', '/foo', ExampleController::class);
 
         $containerMock->expects($this->once())
             ->method('get')
@@ -39,5 +43,17 @@ class ResolverTest extends TestCase
         $resolver = new Resolver($containerMock);
 
         $resolver->resolve($requestMock, $responseMock, $route);
+    }
+
+    public function routeDataProvider(): array
+    {
+        return [
+            'Resolves single-action controller' => [
+                new Route('GET', '/foo', ExampleController::class),
+            ],
+            'Resolves array callable' => [
+                new Route('GET', '/foo', [ExampleController::class, 'index']),
+            ],
+        ];
     }
 }

--- a/tests/KernelTest.php
+++ b/tests/KernelTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests;
+namespace Beast\Framework\Tests;
 
 use Beast\Framework\Http\Middlewares\Kernel;
 use Beast\Framework\Http\Resolver;

--- a/tests/PathsTest.php
+++ b/tests/PathsTest.php
@@ -10,9 +10,9 @@ class PathsTest extends TestCase
 {
     public function testResolve(): void
     {
-        $paths = new Paths(\sys_get_temp_dir());
+        $paths = new Paths(sys_get_temp_dir());
 
-        $this->assertEquals(\realpath(\sys_get_temp_dir()).'/foo/bar.json', $paths->resolve('foo/bar.json'));
+        $this->assertEquals(realpath(sys_get_temp_dir()).'/foo/bar.json', $paths->resolve('foo/bar.json'));
     }
 
     public function testMissingDir(): void

--- a/tests/PathsTest.php
+++ b/tests/PathsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests;
+namespace Beast\Framework\Tests;
 
 use Beast\Framework\Support\Paths;
 use InvalidArgumentException;

--- a/tests/PathsTest.php
+++ b/tests/PathsTest.php
@@ -11,7 +11,8 @@ class PathsTest extends TestCase
     public function testResolve(): void
     {
         $paths = new Paths(\sys_get_temp_dir());
-        $this->assertEquals(\sys_get_temp_dir().'/foo/bar.json', $paths->resolve('foo/bar.json'));
+
+        $this->assertEquals(\realpath(\sys_get_temp_dir()).'/foo/bar.json', $paths->resolve('foo/bar.json'));
     }
 
     public function testMissingDir(): void

--- a/tests/RedisStorageTest.php
+++ b/tests/RedisStorageTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests;
+namespace Beast\Framework\Tests;
 
 use Beast\Framework\Tokens\RedisStorage;
 use PHPUnit\Framework\TestCase;

--- a/tests/RouteTest.php
+++ b/tests/RouteTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests;
+namespace Beast\Framework\Tests;
 
 use Beast\Framework\Router\Route;
 use PHPUnit\Framework\TestCase;

--- a/tests/RoutesTest.php
+++ b/tests/RoutesTest.php
@@ -23,15 +23,12 @@ class RoutesTest extends TestCase
     {
         $routes = new Routes();
         $options = [
-            'namespace' => 'foo',
             'prefix' => 'bar',
         ];
         $routes->addOptions($options);
-        $this->assertEquals('\\foo\\', $routes->getNamespace());
         $this->assertEquals('bar', $routes->getPrefix());
 
         $routes->removeOptions($options);
-        $this->assertEquals('\\', $routes->getNamespace());
         $this->assertEquals('', $routes->getPrefix());
     }
 
@@ -41,11 +38,9 @@ class RoutesTest extends TestCase
         $routes = new Routes([$route]);
 
         $routes->group([
-            'namespace' => 'foo',
             'prefix' => 'bar',
         ], function (Routes $r) use ($routes): void {
             $this->assertEquals($routes, $r);
-            $this->assertEquals('\\foo\\', $routes->getNamespace());
             $this->assertEquals('bar', $routes->getPrefix());
         });
     }

--- a/tests/RoutesTest.php
+++ b/tests/RoutesTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests;
+namespace Beast\Framework\Tests;
 
 use BadMethodCallException;
 use Beast\Framework\Router\Route;

--- a/tests/RoutesTest.php
+++ b/tests/RoutesTest.php
@@ -105,14 +105,6 @@ class RoutesTest extends TestCase
         $this->assertCount(1, $routes);
     }
 
-    public function testCreateByMethodFailure(): void
-    {
-        $routes = new Routes();
-
-        $this->expectException(BadMethodCallException::class);
-        $routes->fail('/', 'callback');
-    }
-
     public function testMatch(): void
     {
         $routes = new Routes();

--- a/tests/RoutesTest.php
+++ b/tests/RoutesTest.php
@@ -2,7 +2,6 @@
 
 namespace Beast\Framework\Tests;
 
-use BadMethodCallException;
 use Beast\Framework\Router\Route;
 use Beast\Framework\Router\RouteNotFoundException;
 use Beast\Framework\Router\Routes;

--- a/tests/SapiEmitterTest.php
+++ b/tests/SapiEmitterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests;
+namespace Beast\Framework\Tests;
 
 use Beast\Framework\Http\SapiEmitter;
 use PHPUnit\Framework\TestCase;

--- a/tests/TableGatewayTest.php
+++ b/tests/TableGatewayTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Tests;
+namespace Beast\Framework\Tests;
 
 use Beast\Framework\Database\EntityInterface;
 use Beast\Framework\Database\TableGateway;


### PR DESCRIPTION
Although no immediate code benefit, it does allow for better code navigation and better understanding of where code is called and used within IDE's.

The syntax `controller@method` to me is "magic", as the Resolver has to manually break up the string and resolve each counterpart to understand if it corresponds to not only a controller, but also a Route.

This is a BC change, therefore, we will need to increment the major version number. 

Once merged, downstream apps using this library will need to update their routes file. I can do this for our internal applications.